### PR TITLE
chore: support comment_file arg to post PR comment with contents from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## This was forked from the original [aoldershaw/github-pr-resource](https://github.com/aoldershaw/github-pr-resource)
-to add an additional security check when looking at PR approvals. 
+to add an additional security check when looking at PR approvals.
 
 You can find it on Dockerhub as the `tasruntime/github-pr-instances-resource` image.
 
@@ -201,11 +201,12 @@ empty commit to the PR*.
 | `base_context`             | No       | `concourse-ci`                       | Base context (prefix) used for the status context. Defaults to `concourse-ci`.                                                                                |
 | `context`                  | No       | `unit-test`                          | A context to use for the status, which is prefixed by `base_context`. Defaults to `"status"`.                                                                 |
 | `comment`                  | No       | `hello world!`                       | A comment to add to the pull request.                                                                                                                         |
+| `comment_file`             | No       | `my-output/comment.txt`              | Path to file containing a comment to add to the pull request                                                                                                  |
 | `target_url`               | No       | `$ATC_EXTERNAL_URL/builds/$BUILD_ID` | The target URL for the status, where users are sent when clicking details (defaults to the Concourse build page).                                             |
 | `description`              | No       | `Concourse CI build failed`          | The description status on the specified pull request.                                                                                                         |
 | `delete_previous_comments` | No       | `true`                               | Boolean. Previous comments made on the pull request by this resource will be deleted before making the new comment. Useful for removing outdated information. |
 
-Note that `comment`, `context,` and `target_url` will all expand environment variables, so in the examples above `$ATC_EXTERNAL_URL` will be replaced by the public URL of the Concourse ATCs.
+Note that `comment`, `comment_file`, `context,` and `target_url` will all expand environment variables, so in the examples above `$ATC_EXTERNAL_URL` will be replaced by the public URL of the Concourse ATCs.
 See https://concourse-ci.org/implementing-resource-types.html#resource-metadata for more details about metadata that is available via environment variables.
 
 ## Example

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 vars:
   BUILD_DIR: build

--- a/pr/out.go
+++ b/pr/out.go
@@ -65,6 +65,21 @@ func Put(request PutRequest, github models.Github, inputDir string) (*PutRespons
 		}
 	}
 
+	// Set comment from a file if specfied
+	if p := request.Params; p.CommentFile != "" {
+		content, err := ioutil.ReadFile(filepath.Join(inputDir, p.CommentFile))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read comment file: %s", err)
+		}
+		comment := string(content)
+		if comment != "" {
+			err = github.PostComment(prNumber, safeExpandEnv(comment))
+			if err != nil {
+				return nil, fmt.Errorf("failed to post comment: %s", err)
+			}
+		}
+	}
+
 	return &PutResponse{
 		Version:  version,
 		Metadata: metadata,
@@ -89,6 +104,7 @@ type PutParameters struct {
 	Description            string `json:"description"`
 	Status                 string `json:"status"`
 	Comment                string `json:"comment"`
+	CommentFile            string `json:"comment_file"`
 	DeletePreviousComments bool   `json:"delete_previous_comments"`
 }
 


### PR DESCRIPTION
Would be useful to be able to send PR comments from file content rather than string arg on the `put` similar to what this resource does: https://github.com/telia-oss/github-pr-resource